### PR TITLE
Clarify Spack installation with version specification

### DIFF
--- a/docs/BuildInstall/spack_installation.md
+++ b/docs/BuildInstall/spack_installation.md
@@ -103,6 +103,7 @@ The default version will be the latest stable release. However, you can also ask
 !!! note "Install exaStamp specific version"
   
     ```bash
+    spack install exastamp@3.7.4
     spack install exastamp@3.7.3
     spack install exastamp@3.7.2
     spack install exastamp@3.7.0

--- a/docs/BuildInstall/spack_installation.md
+++ b/docs/BuildInstall/spack_installation.md
@@ -4,7 +4,7 @@ icon: simple/linux
 
 # **Installation with Spack**
 
-Installation with `Spack` is easy and preferable for users who don't want to develop in `exaStamp`. Only stable versions are added when you install `exaStamp` with `Spack`, meaning that it doesn't provide you access to the development branches. In addition, the main branch of `exaStamp` will never be directly accessible via this installation method.
+Installation with `Spack` is easy and preferable for users who don't want to develop in `exaStamp`. Only stable versions are added when you install `exaStamp` with `Spack` (version `1.1.0`), meaning that it doesn't provide you access to the development branches. In addition, the main branch of `exaStamp` will never be directly accessible via this installation method.
 
 ## **Minimal requirements**
 
@@ -16,7 +16,7 @@ Below are instructions to first retrieve spack sources and install it on your sy
   
     ```bash
     cd ${HOME}/dev
-    git clone https://github.com/spack/spack.git
+    git clone --depth=2 --branch=v1.1.0 https://github.com/spack/spack.git
     export SPACK_ROOT=${HOME}/dev/spack
     source ${SPACK_ROOT}/share/spack/setup-env.sh
     ```

--- a/docs/microStamp/spack_installation.md
+++ b/docs/microStamp/spack_installation.md
@@ -16,7 +16,7 @@ Below are instructions to first retrieve spack sources and install it on your sy
   
     ```bash
     cd ${HOME}/dev
-    git clone https://github.com/spack/spack.git
+    git clone --depth=2 --branch=v1.1.0 https://github.com/spack/spack.git
     export SPACK_ROOT=${HOME}/dev/spack
     source ${SPACK_ROOT}/share/spack/setup-env.sh
     ```
@@ -87,20 +87,20 @@ Then, simply install `exaNBody`. To get access to the `microStamp` mini applicat
 !!! note "Install exaNBody"
   
     ```bash
-    spack install exaNBody+contribs
+    spack install exanbody+contribs
     ```
 
 If you have a GPU on your machine, you can also ask for a CUDA installation through the following command:
   
-!!! note "Install exaStamp with CUDA support"
+!!! note "Install exaNBody + contribs with CUDA support"
 
     ```bash
-    spack install exastamp+contribs+cuda
+    spack install exanbody+contribs+cuda
     ```
 
 The default version will be the latest stable release. However, you can also ask for a specific branch as follow:
 
-Finally, the commands listed above will install the appropriate version of `cmake`, `yaml-cpp`, `onika` and `exaNBody` and additional required packages by the `exaStamp` recipe. Eventually, to run an `exaStamp` case, do the following:
+Finally, the commands listed above will install the appropriate version of `cmake`, `yaml-cpp`, `onika` and `exaNBody` and additional required packages allowing you to run MD simulations directly with `exaNBody`. Eventually, to run an `exaNBody` case, do the following:
 
 !!! note "Install exaStamp"
   


### PR DESCRIPTION
Updated Spack installation instructions to specify version 1.1.0 and added a depth parameter to the git clone command.